### PR TITLE
Add support to print library size

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,19 @@
+# Rubrik SharePoint Metrics Collector
+
+## Overview
+This repo contains the PowerShell script to get statistics on O365 environment.
+
+Required Modules:
+```
+Install-Module -Name Microsoft.Online.SharePoint.PowerShell -RequiredVersion 16.0.8029.0
+Install-Module -Name SharePointPnPPowerShellOnline -RequiredVersion 3.21.2005.1
+```
+
+## Using ths module
+$userid = "admine@domain.com"
+$password = "MyPass123!"
+$securedPassword = ConvertTo-SecureString $password -AsPlainText -Force
+$TenantAdminURL = "https://yourtenant-admin.domain.com"
+ .\SharePoint\SPOMetrics.ps1 -User $userid -Password $securePassword -AdminURL $TenantAdminURL
+
+This will create 2 csv files: SPMetricsLibs.csv and SPMetricsList.csv

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # polaris-0365-environment-discovery
 
 ## :hammer: Installation
-
+See [Quick Start Guide](QUICK_START.md) for isntallation and usage instructions.
 ## :mag: Example
 
 ## :blue_book: Documentation

--- a/SharePoint/SPOMetrics.ps1
+++ b/SharePoint/SPOMetrics.ps1
@@ -152,7 +152,7 @@ Function GetMetricsForsite($url)
                     $allItems=Get-PnPFolderItem -FolderSiteRelativeUrl $Rootfolder -Recursive -ErrorAction Stop
                     if($Error[0])
                     {  
-                        $LibInfo = [pscustomobject]@{SiteURL ="";"Group count"="";"Lib"=$listUrl;"Folders"="Error Occured";"Files"="Error Occured";"storageUsed(inMB)"=""}
+                        $LibInfo = [pscustomobject]@{SiteURL ="";"Group count"="";"Lib"=$listUrl;"Folders"="Error Occured";"Files"="Error Occured";"storageUsed(inMB)"="";"docLibUsed(inMB)"=""}
                     }
                     else
                     {
@@ -160,7 +160,15 @@ Function GetMetricsForsite($url)
                         if($allItems)
                         {
                             $allFolders = $allItems | Where-Object {$_.TypedObject.ToString() -eq "Microsoft.SharePoint.Client.Folder"} 
-                            $allFiles   = $allItems | Where-Object {$_.TypedObject.ToString() -eq "Microsoft.SharePoint.Client.File"} 
+                            $allFiles   = $allItems | Where-Object {$_.TypedObject.ToString() -eq "Microsoft.SharePoint.Client.File"}
+                            $folderSize=0
+                            foreach ($item in $allFiles) {
+                                if($item.Length)
+                                {
+                                    $folderSize+=$item.Length        
+                                }
+                            } 
+                            $folderSize=($folderSize/1024/1024)
                             if(!$allFolders)
                             {
                                 $folderCount=0
@@ -174,7 +182,7 @@ Function GetMetricsForsite($url)
                                 else
                                 {
                                     $folderCount=$allFolders.Length
-                            }
+                                }
                             }
                             if(!$allFiles)
                             {
@@ -189,20 +197,21 @@ Function GetMetricsForsite($url)
                                 else
                                 {
                                     $filesCount=$allFiles.Length
+                                    Write-Host "Folder Size: "$folderSize
                                 }
                             }
-                            $LibInfo = [pscustomobject]@{SiteURL ="";"Group count"="";"Lib"=$listUrl;"Folders"=$folderCount;"Files"=$filesCount;"storageUsed(inMB)"=""}
+                            $LibInfo = [pscustomobject]@{SiteURL ="";"Group count"="";"Lib"=$listUrl;"Folders"=$folderCount;"Files"=$filesCount;"storageUsed(inMB)"="";"docLibUsed(inMB)"=$folderSize}
                         }
                         else
                         {
-                            $LibInfo = [pscustomobject]@{SiteURL ="";"Group count"="";"Lib"=$listUrl;"Folders"=0;"Files"=0;"storageUsed(inMB)"=""}
+                            $LibInfo = [pscustomobject]@{SiteURL ="";"Group count"="";"Lib"=$listUrl;"Folders"=0;"Files"=0;"storageUsed(inMB)"="";"docLibUsed(inMB)"=""}
                         }
                     }
                 }
                 catch
                 {
                     Write-host "Error occured"    
-                    $LibInfo = [pscustomobject]@{SiteURL ="";"Group count"="";"Lib"=$listUrl;"Folders"="Error Occured";"Files"="Error Occured";"storageUsed(inMB)"=""}
+                    $LibInfo = [pscustomobject]@{SiteURL ="";"Group count"="";"Lib"=$listUrl;"Folders"="Error Occured";"Files"="Error Occured";"storageUsed(inMB)"="";"docLibUsed(inMB)"=""}
                 }    
                 $AllLibInSiteInfo+=$LibInfo
             }
@@ -222,7 +231,7 @@ Function GetMetricsForsite($url)
             $GroupCount="Error Occured"
         }
         $SiteInfoHeaderList += [pscustomobject]@{SiteURL = $url ;"Group count"=$GroupCount  ;"storageUsed(inMB)"=$sitecollectionStorage ;"List"="";"Items"=""}
-        $SiteInfoHeaderLib += [pscustomobject]@{SiteURL = $url;"Group count"=$GroupCount;List="";"storageUsed(inMB)"=$sitecollectionStorage;"Lib"="";"Folders"="";"Files"=""}
+        $SiteInfoHeaderLib += [pscustomobject]@{SiteURL = $url;"Group count"=$GroupCount;List="";"storageUsed(inMB)"=$sitecollectionStorage;"Lib"="";"Folders"="";"Files"="";"docLibUsed(inMB)"=""}
     }
     else
     {
@@ -323,7 +332,7 @@ $TenantUrl=$TenantAdminURL.Replace("-admin","")
 Connect-SPOService -Url $TenantAdminURL -Credential $Credential
 #if($AllSites)
 #{
-    $AllSiteCollections=get-sposite -Limit All  | Select Url,Title,StorageUsageCurrent| Sort-Object StorageUsageCurrent -Descending
+    $AllSiteCollections=get-sposite -Limit ALL | Select Url,Title,StorageUsageCurrent| Sort-Object StorageUsageCurrent -Descending
 #}
 #write-host $AllSiteCollections
 Get-Metrics($AllSiteCollections)
@@ -331,4 +340,4 @@ Get-Metrics($AllSiteCollections)
 
 
 
-    
+ 


### PR DESCRIPTION
# Description

Add support to get library size in mb

## Related Issue

<!-- Please link to the issue here-->

<!-- If no issue exsits for your pull request, please use a draft pull requests for discussion purposes-->

## Motivation and Context

Need storage used for each library to get better gauge of customer environment

## How Has This Been Tested?

Script ran on Windows 10 machine against internal test SharePoint tenant

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.